### PR TITLE
Update _load_sbert_model Parameters and Fix Tokenize Padding

### DIFF
--- a/InstructorEmbedding/instructor.py
+++ b/InstructorEmbedding/instructor.py
@@ -517,20 +517,24 @@ class INSTRUCTOR(SentenceTransformer):
 
         return batched_input_features, labels
 
-    def _load_sbert_model(self, model_path, token = None, cache_folder = None, revision = None, trust_remote_code = False):
+    def _load_sbert_model(self, model_path, token=None, cache_folder=None, revision=None, trust_remote_code=False):
         """
         Loads a full sentence-transformers model
         """
-        # Taken mostly from: https://github.com/UKPLab/sentence-transformers/blob/66e0ee30843dd411c64f37f65447bb38c7bf857a/sentence_transformers/util.py#L544
-        download_kwargs = {
-            "repo_id": model_path,
-            "revision": revision,
-            "library_name": "sentence-transformers",
-            "token": token,
-            "cache_dir": cache_folder,
-            "tqdm_class": disabled_tqdm,
-        }
-        model_path = snapshot_download(**download_kwargs)
+        if os.path.isdir(model_path):
+            # If model_path is a local directory, load the model directly
+            model_path = str(model_path)
+        else:
+            # If model_path is a Hugging Face repository ID, download the model
+            download_kwargs = {
+                "repo_id": model_path,
+                "revision": revision,
+                "library_name": "sentence-transformers",
+                "token": token,
+                "cache_dir": cache_folder,
+                "tqdm_class": disabled_tqdm,
+            }
+            model_path = snapshot_download(**download_kwargs)
 
         # Check if the config_sentence_transformers.json file exists (exists since v2 of the framework)
         config_sentence_transformers_json_path = os.path.join(

--- a/InstructorEmbedding/instructor.py
+++ b/InstructorEmbedding/instructor.py
@@ -395,7 +395,7 @@ class INSTRUCTORTransformer(Transformer):
 
             input_features = self.tokenizer(
                 *to_tokenize,
-                padding="max_length",
+                padding=True,
                 truncation="longest_first",
                 return_tensors="pt",
                 max_length=self.max_seq_length,

--- a/InstructorEmbedding/instructor.py
+++ b/InstructorEmbedding/instructor.py
@@ -517,7 +517,7 @@ class INSTRUCTOR(SentenceTransformer):
 
         return batched_input_features, labels
 
-    def _load_sbert_model(self, model_path, token=None, cache_folder=None, revision=None, trust_remote_code=False):
+    def _load_sbert_model(self, model_path, token=None, cache_folder=None, revision=None, trust_remote_code=False, local_files_only=False, model_kwargs=None, tokenizer_kwargs=None, config_kwargs=None):
         """
         Loads a full sentence-transformers model
         """

--- a/InstructorEmbedding/instructor.py
+++ b/InstructorEmbedding/instructor.py
@@ -23,7 +23,7 @@ def batch_to_device(batch, target_device: str):
     return batch
 
 
-class InstructorPooling(nn.Module):
+class INSTRUCTORPooling(nn.Module):
     """Performs pooling (max or mean) on the token embeddings.
 
     Using pooling, it generates from a variable sized sentence a fixed sized sentence embedding.
@@ -245,7 +245,7 @@ class InstructorPooling(nn.Module):
         ) as config_file:
             config = json.load(config_file)
 
-        return InstructorPooling(**config)
+        return INSTRUCTORPooling(**config)
 
 
 def import_from_string(dotted_path):
@@ -271,7 +271,7 @@ def import_from_string(dotted_path):
         raise ImportError(msg)
 
 
-class InstructorTransformer(Transformer):
+class INSTRUCTORTransformer(Transformer):
     def __init__(
         self,
         model_name_or_path: str,
@@ -378,7 +378,7 @@ class InstructorTransformer(Transformer):
 
         with open(sbert_config_path, encoding="UTF-8") as config_file:
             config = json.load(config_file)
-        return InstructorTransformer(model_name_or_path=input_path, **config)
+        return INSTRUCTORTransformer(model_name_or_path=input_path, **config)
 
     def tokenize(self, texts):
         """
@@ -420,7 +420,7 @@ class InstructorTransformer(Transformer):
 
             input_features = self.tokenize(instruction_prepended_input_texts)
             instruction_features = self.tokenize(instructions)
-            input_features = Instructor.prepare_input_features(
+            input_features = INSTRUCTOR.prepare_input_features(
                 input_features, instruction_features
             )
         else:
@@ -430,7 +430,7 @@ class InstructorTransformer(Transformer):
         return output
 
 
-class Instructor(SentenceTransformer):
+class INSTRUCTOR(SentenceTransformer):
     @staticmethod
     def prepare_input_features(
         input_features, instruction_features, return_data_type: str = "pt"
@@ -510,7 +510,7 @@ class Instructor(SentenceTransformer):
 
             input_features = self.tokenize(instruction_prepended_input_texts)
             instruction_features = self.tokenize(instructions)
-            input_features = Instructor.prepare_input_features(
+            input_features = INSTRUCTOR.prepare_input_features(
                 input_features, instruction_features
             )
             batched_input_features.append(input_features)
@@ -559,9 +559,9 @@ class Instructor(SentenceTransformer):
         modules = OrderedDict()
         for module_config in modules_config:
             if module_config["idx"] == 0:
-                module_class = InstructorTransformer
+                module_class = INSTRUCTORTransformer
             elif module_config["idx"] == 1:
-                module_class = InstructorPooling
+                module_class = INSTRUCTORPooling
             else:
                 module_class = import_from_string(module_config["type"])
             module = module_class.load(os.path.join(model_path, module_config["path"]))

--- a/InstructorEmbedding/instructor.py
+++ b/InstructorEmbedding/instructor.py
@@ -23,7 +23,7 @@ def batch_to_device(batch, target_device: str):
     return batch
 
 
-class INSTRUCTORPooling(nn.Module):
+class INSTRUCTOR_Pooling(nn.Module):
     """Performs pooling (max or mean) on the token embeddings.
 
     Using pooling, it generates from a variable sized sentence a fixed sized sentence embedding.
@@ -245,7 +245,7 @@ class INSTRUCTORPooling(nn.Module):
         ) as config_file:
             config = json.load(config_file)
 
-        return INSTRUCTORPooling(**config)
+        return INSTRUCTOR_Pooling(**config)
 
 
 def import_from_string(dotted_path):
@@ -573,7 +573,7 @@ class INSTRUCTOR(SentenceTransformer):
             if module_config["idx"] == 0:
                 module_class = INSTRUCTORTransformer
             elif module_config["idx"] == 1:
-                module_class = INSTRUCTORPooling
+                module_class = INSTRUCTOR_Pooling
             else:
                 module_class = import_from_string(module_config["type"])
             module = module_class.load(os.path.join(model_path, module_config["path"]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy
 requests>=2.26.0
 scikit_learn>=1.0.2
 scipy
-sentence_transformers>=2.2.0
+sentence_transformers>=2.3.0
 torch
 tqdm
 rich

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", mode="r", encoding="utf-8") as readme_file:
 setup(
     name='InstructorEmbedding',
     packages=['InstructorEmbedding'],
-    version='1.0.1',
+    version='1.0.2',
     license='Apache License 2.0',
     description='Text embedding tool',
     long_description=readme,


### PR DESCRIPTION
## Summary
This pull request addresses two significant updates to the `InstructorEmbedding` functionality to improve compatibility and performance when using sentence-transformers version 3.0.1.

## Changes Introduced:
1. **Refactor: Added Missing Parameters to `_load_sbert_model` for Enhanced Compatibility**
   - Parameters added:
     - `local_files_only=False`
     - `model_kwargs=None`
     - `tokenizer_kwargs=None`
     - `config_kwargs=None`
   - These parameters were missing and are now included to ensure compatibility with sentence-transformers 3.0.1.
   
2. **Refactor: Updated `tokenize` Method's Padding Parameter Back to `True`**
   - Changed the `padding` parameter from `"max_length"` back to `True`.
   - This modification addresses a significant performance bottleneck observed in encoding operations, particularly impacting softmax and linear layers.
   - The performance profile comparison underscores the benefit of this change.

## Performance Comparison:
- **With `padding=True`:**
  ```
  ncalls  tottime  percall  cumtime  percall  filename:lineno(function)
  145     0.558    0.004    0.558    0.004    {built-in method torch._C._nn.linear}
  24      0.083    0.003    0.440    0.018    .venv\lib\site-packages\transformers\models\t5\modeling_t5.py:279(forward)
  24      0.041    0.002    0.041    0.002    {method 'softmax' of 'torch._C.TensorBase' objects}
  ```

- **With `padding="max_length"`:**
  ```
  24      3.274    0.136    3.274    0.136    {method 'softmax' of 'torch._C.TensorBase' objects}
  145     3.253    0.022    3.253    0.022    {built-in method torch._C._nn.linear}
  24      0.625    0.026    5.479    0.228    .venv\lib\site-packages\transformers\models\t5\modeling_t5.py:445(forward)
  ```

## Additional Note
- There might have been a valid reason to choose padding="max_length" for better performance during parallelization. However, I did not test for this case and therefore cannot speak for it. If so, there should at least be a parameter to choose the padding strategy.

## Testing:
- The updated methods were tested using sentence-transformers 3.0.1 on a CPU with a batch size of 1 on a single sentence to validate the functional and performance improvements.


Please review the changes and let me know if any further adjustments are necessary.

Thank you for considering this request. I look forward to your feedback.